### PR TITLE
Stricter validation and out-of-order support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+notes
 /target
 **/*.rs.bk
 Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "1.2.0"
 authors = ["Piet Geursen <pietgeursen@gmail.com>", "Andrew Reid <glyph@mycelial.technology>"]
 edition = "2018"
 description = "Verify Secure Scuttlebutt (SSB) hash chains (in parallel)"
-repository = "https://github.com/mycognosist/ssb-validate"
+repository = "https://github.com/sunrise-choir/ssb-validate"
 documentation = "https://docs.rs/ssb-validate/"
 license = "AGPL-3.0"
 
@@ -14,7 +14,7 @@ regex = "1.5"
 serde = { version = "1.0", features = ["derive"] }
 sha2 = "0.8.0"
 snafu = "0.6.0"
-ssb-legacy-msg-data = { git = "https://github.com/mycognosist/legacy-msg-data" }
+ssb-legacy-msg-data = { git = "https://github.com/sunrise-choir/legacy-msg-data" }
 ssb-multiformats = "0.4.0" 
 rayon = "1.2.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,18 +1,18 @@
 [package]
 name = "ssb-validate"
-version = "1.0.1"
-authors = ["Piet Geursen <pietgeursen@gmail.com>"]
+version = "1.1.0"
+authors = ["Piet Geursen <pietgeursen@gmail.com>", "Andrew Reid <glyph@mycelial.technology>"]
 edition = "2018"
 description = "Verify Secure Scuttlebutt (SSB) hash chains (in parallel)"
-repository = "https://github.com/sunrise-choir/ssb-validate"
+repository = "https://github.com/mycognosist/ssb-validate"
 documentation = "https://docs.rs/ssb-validate/"
 license = "AGPL-3.0"
 
 [dependencies]
+regex = "1.5"
 serde = { version = "1.0", features = ["derive"] }
 sha2 = "0.8.0"
 snafu = "0.6.0"
-#ssb-legacy-msg-data = "0.1.2"
 ssb-legacy-msg-data = { git = "https://github.com/mycognosist/legacy-msg-data" }
 ssb-multiformats = "0.4.0" 
 rayon = "1.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,8 @@ license = "AGPL-3.0"
 serde = { version = "1.0", features = ["derive"] }
 sha2 = "0.8.0"
 snafu = "0.6.0"
-ssb-legacy-msg-data = "0.1.2"
+#ssb-legacy-msg-data = "0.1.2"
+ssb-legacy-msg-data = { path = "../ssb-legacy-msg-data" }
 ssb-multiformats = "0.4.0" 
 rayon = "1.2.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssb-validate"
-version = "1.1.0"
+version = "1.2.0"
 authors = ["Piet Geursen <pietgeursen@gmail.com>", "Andrew Reid <glyph@mycelial.technology>"]
 edition = "2018"
 description = "Verify Secure Scuttlebutt (SSB) hash chains (in parallel)"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ serde = { version = "1.0", features = ["derive"] }
 sha2 = "0.8.0"
 snafu = "0.6.0"
 #ssb-legacy-msg-data = "0.1.2"
-ssb-legacy-msg-data = { path = "../ssb-legacy-msg-data" }
+ssb-legacy-msg-data = { git = "https://github.com/mycognosist/legacy-msg-data" }
 ssb-multiformats = "0.4.0" 
 rayon = "1.2.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ documentation = "https://docs.rs/ssb-validate/"
 license = "AGPL-3.0"
 
 [dependencies]
+lazy_static = "1.4.0"
 regex = "1.5"
 serde = { version = "1.0", features = ["derive"] }
 sha2 = "0.8.0"

--- a/README.md
+++ b/README.md
@@ -18,23 +18,23 @@ Secure Scuttlebutt "feeds" are a sequence of messages published by one author. T
 
 If the message is the first in the feed:
 
- [x] - the value of the `previous` field must be `null`
- [x] - the value of the `sequence` field must be `1`
+ - the value of the `previous` field must be `null`
+ - the value of the `sequence` field must be `1`
 
 If the message is not the first in the feed:
 
- [x] - the value of the `previous` field must be the hash of the previous message
- [x] - the value of the `sequence` field must be 1 larger than the `sequence` of the previous message
+ - the value of the `previous` field must be the hash of the previous message
+ - the value of the `sequence` field must be 1 larger than the `sequence` of the previous message
 
 Other criteria which all messages must satisfy (unless they are being validated out-of-order):
 
- [x] - the value of the `hash` field must be `sha256`
- [x] - the `author` must not change compared to the previous message
- [x] - if the message includes a `key`, it must be the hash of the `value` of the message
- [x] - message `value` fields must be in the order: `previous`, `author` or `sequence`, `author` or `sequence`, `timestamp`, `hash`, `content`, `signature`
- [x] - the message `value` must not include extra (unexpected) fields
- [x] - the value of the message `content` field must be encoded in canonical base64 and contain `.box` if it is a string (encrypted private message)
- [x] - the length of the serialized message `value` must not exceed 8192 UTF-16 code units
+ - the value of the `hash` field must be `sha256`
+ - the `author` must not change compared to the previous message
+ - if the message includes a `key`, it must be the hash of the `value` of the message
+ - message `value` fields must be in the order: `previous`, `author` or `sequence`, `author` or `sequence`, `timestamp`, `hash`, `content`, `signature`
+ - the message `value` must not include extra (unexpected) fields
+ - the value of the message `content` field must be encoded in canonical base64 and contain `.box` if it is a string (encrypted private message)
+ - the length of the serialized message `value` must not exceed 8192 UTF-16 code units
 
 All of the above criteria are validated by this library (either directly or via dependencies).
 
@@ -51,11 +51,11 @@ Multi-author out-of-order validation, by contrast to the above, does not perform
 ## Useful Documentation
 
  - [Rust docs for the Sunrise Choir version of ssb-validate](https://sunrise-choir.github.io/ssb-validate/ssb_validate/index.html)
- - [Specification for data type, data model, feed and messages](https://spec.scuttlebutt.nz/): detailed information for developers working at the protocol level.
- - [Scuttlebutt Protocol Guide](https://ssbc.github.io/scuttlebutt-protocol-guide/index.html): excellent overview of the SSB protocol (required reading).
- - [User-guide for Sunrise Choir crates](https://dev.scuttlebutt.nz/#/rust/sunrise-choir): should be useful for application developers.
+ - [User-guide for Sunrise Choir crates](https://dev.scuttlebutt.nz/#/rust/sunrise-choir): should be useful for application developers
+ - [Specification for data type, data model, feed and messages](https://spec.scuttlebutt.nz/): detailed information for developers working at the protocol level
+ - [Scuttlebutt Protocol Guide](https://ssbc.github.io/scuttlebutt-protocol-guide/index.html): excellent overview of the SSB protocol (required reading)
 
-The doc comments for this crate and all dependencies can be built and served locally by clonging the repo and running `cargo doc --open`. You can find more information about `cargo doc` [here](https://doc.rust-lang.org/cargo/commands/cargo-doc.html).
+The doc comments for this crate and all dependencies can be built and served locally by cloning the repo and running `cargo doc --open`. You can find more information about `cargo doc` [here](https://doc.rust-lang.org/cargo/commands/cargo-doc.html).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,30 +1,40 @@
-[![Build Status](https://travis-ci.org/sunrise-choir/ssb-validate.svg?branch=master)](https://travis-ci.org/sunrise-choir/ssb-validate)
 # ssb-validate
 
-> Verify Secure Scuttlebutt (SSB) hash chains (in parallel)
+Validate Secure Scuttlebutt (SSB) hash chains (in parallel)
 
-**THIS FORK DEVIATES SIGNIFICANTLY FROM THE ORIGINAL VERSION!** Support for out-of-order validation (regular and parallel) and multi-author out-of-order validation (regular and parallel) has been added.
+:warning: **Warning: this fork deviates significantly from the Sunrise Choir repository.** The primary difference is in the strictness of validation, with this fork including additional validation checks. The aim here is to get as close as possible to the full set of validation criteria employed by the [JavaScript implementation of ssb-validate](https://github.com/ssb-js/ssb-validate).
 
-## Docs
+Support for out-of-order validation (regular and parallel) and multi-author out-of-order validation (regular and parallel) has been added.
 
-[Rustdocs](https://sunrise-choir.github.io/ssb-validate/ssb_validate/index.html)
+## Usage
 
-## About
+Visit the [ssb-validate2-rsjs](https://github.com/ssb-ngi-pointer/ssb-validate2-rsjs) repo (the `src/lib.rs` file in particular) to see examples of this crate in action. The validation functionality is paired with [ssb-verify-signatures](https://github.com/sunrise-choir/ssb-verify-signatures) to perform complete validation of SSB messages. A technique for returning an invalid message when performing parallel validation is also included in the code.
 
-Secure Scuttlebutt "feeds" are a sequence of messages published by one author.
-To be valid, a message should satisfy the following criteria:
+Further examples can be seen in the tests of `src/lib.rs` in this repo.
 
- - include the hash of the previous message
-   - unless it is the first message in feed, in which case previous must be null
- - include a sequence number which is 1 larger than the sequence number of the previous message
-   - unless it is the first message in a feed, in which case the sequence number must be 1 and the sequence number of the previous message must be null
- - include a hash function field with value `sha256`
- - the author must not change compared to the previous message
- - if the message includes a key, it must be the hash of the value of the message
- - message value keys must be in the order: "previous", "author"|"sequence", "author"|"sequence", "timestamp", "hash", "content", "signature"
- - the message value must not include extra fields
- - if the message content is a string (encrypted private message) it must be encoded in canonical base64 and end with `.box`
- - the length of the serialized message value must not exceed 8192 UTF-16 code units
+## Validation Critera
+
+Secure Scuttlebutt "feeds" are a sequence of messages published by one author. To be valid, a message must satisfy a number of criteria. The exact criteria depend on the context of the message. It's important to note that this crate does not perform signature verification. See the [ssb-verify-signatures](https://github.com/sunrise-choir/ssb-verify-signatures) repo for that functionality.
+
+If the message is the first in the feed:
+
+ [x] - the value of the `previous` field must be `null`
+ [x] - the value of the `sequence` field must be `1`
+
+If the message is not the first in the feed:
+
+ [x] - the value of the `previous` field must be the hash of the previous message
+ [x] - the value of the `sequence` field must be 1 larger than the `sequence` of the previous message
+
+Other criteria which all messages must satisfy (unless they are being validated out-of-order):
+
+ [x] - the value of the `hash` field must be `sha256`
+ [x] - the `author` must not change compared to the previous message
+ [x] - if the message includes a `key`, it must be the hash of the `value` of the message
+ [x] - message `value` fields must be in the order: `previous`, `author` or `sequence`, `author` or `sequence`, `timestamp`, `hash`, `content`, `signature`
+ [x] - the message `value` must not include extra (unexpected) fields
+ [x] - the value of the message `content` field must be encoded in canonical base64 and contain `.box` if it is a string (encrypted private message)
+ [x] - the length of the serialized message `value` must not exceed 8192 UTF-16 code units
 
 All of the above criteria are validated by this library (either directly or via dependencies).
 
@@ -38,9 +48,15 @@ When performing validation for out-of-order messages from a single author, the m
 
 Multi-author out-of-order validation, by contrast to the above, does not perform any checks of the `previous` message. Indeed, it may be said that this method of validation has no concept of a previous message (except that the `previous` field must be present in the message in the correct order).
 
-## Benchmarks
+## Useful Documentation
 
-Benchmarking on a 2016 2 core i5 shows that batch processing  is ~3.6 times faster than using [verify_message] 
+ - [Rust docs for the Sunrise Choir version of ssb-validate](https://sunrise-choir.github.io/ssb-validate/ssb_validate/index.html)
+ - [Specification for data type, data model, feed and messages](https://spec.scuttlebutt.nz/): detailed information for developers working at the protocol level.
+ - [Scuttlebutt Protocol Guide](https://ssbc.github.io/scuttlebutt-protocol-guide/index.html): excellent overview of the SSB protocol (required reading).
+ - [User-guide for Sunrise Choir crates](https://dev.scuttlebutt.nz/#/rust/sunrise-choir): should be useful for application developers.
 
-Benchmarking on Android on a [One Plus 5T](https://en.wikipedia.org/wiki/OnePlus_5T) (8 core arm64) shows that batch processing with [par_verify_messages] is ~9.9 times faster than using [verify_message]! 
+The doc comments for this crate and all dependencies can be built and served locally by clonging the repo and running `cargo doc --open`. You can find more information about `cargo doc` [here](https://doc.rust-lang.org/cargo/commands/cargo-doc.html).
 
+## License
+
+AGPL-3.0

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 
 > Verify Secure Scuttlebutt (SSB) hash chains (in parallel)
 
+**THIS FORK DEVIATES SIGNIFICANTLY FROM THE ORIGINAL VERSION!** Support for out-of-order validation (regular and parallel) and multi-author out-of-order validation (regular and parallel) has been added.
+
 ## Docs
 
 [Rustdocs](https://sunrise-choir.github.io/ssb-validate/ssb_validate/index.html)
@@ -29,7 +31,11 @@ You can check messages one by one or batch process a collection of them (uses [r
 
 In addition to validating messages using all of the above criteria, it is also possible to validate out-of-order messages by satifying a subset of those criteria. This crate provides functions to perform batch validation of such out-of-order messages.
 
-Out-of-order messages must be authored by a single keypair. However, it is not required that the sequence number of a message be 1 larger than the sequence number of the previous message, nor is it required that the hash of the previous message match the hash given for the previous message in a message.
+Out-of-order message validation may be performed for single-author or multi-author use-cases (separate functions exist for each case).
+
+When performing validation for out-of-order messages from a single author, the messages must be authored by a single keypair. However, it is not required that the sequence number of a message be 1 larger than the sequence number of the previous message, nor is it required that the hash of the previous message match the hash given for the previous message in a message.
+
+Multi-author out-of-order validation, by contrast to the above, does not perform any checks of the `previous` message. Indeed, it may be said that this method of validation has no concept of a previous message (except that the `previous` field must be present in the message in the correct order).
 
 ## Benchmarks
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ To be valid, a message should satisfy the following criteria:
  - include a hash function field with value `sha256`
  - the author must not change compared to the previous message
  - if the message includes a key, it must be the hash of the value of the message
+ - message value keys must be in the order: "previous", "author"|"sequence", "author"|"sequence", "timestamp", "hash", "content", "signature"
  - the message value must not include extra fields
  - if the message content is a string (encrypted private message) it must be encoded in canonical base64 and end with `.box`
 

--- a/README.md
+++ b/README.md
@@ -10,14 +10,20 @@
 ## About
 
 Secure Scuttlebutt "feeds" are a sequence of messages published by one author.
-To be a valid message,
-- each message must include the hash of the preceding message
-- the sequence number must be one larger than sequence of the preceding message
-- the author must not change compared to the preceding message
-- If it's the first message in a feed, the sequence must be 1 and the previous must be null.
-- If the message includes the key, it must be that hash of the value of the message..
+To be valid, a message should satisfy the following criteria:
+
+ - include the hash of the previous message
+   - unless it is the first message in feed, in which case previous must be null
+ - include a sequence number which is 1 larger than the sequence number of the previous message
+   - unless it is the first message in a feed, in which case the sequence number must be 1 and the sequence number of the previous message must be null
+ - the author must not change compared to the previous message
+ - if the message includes a key, it must be the hash of the value of the message
 
 You can check messages one by one or batch process a collection of them (uses [rayon](https://docs.rs/rayon/1.2.0/rayon/index.html) internally)
+
+In addition to validating messages using all of the above criteria, it is also possible to validate out-of-order messages by satifying a subset of those criteria. This crate provides functions to perform batch validation of such out-of-order messages.
+
+Out-of-order messages must be authored by a single keypair. However, it is not required that the sequence number of a message be 1 larger than the sequence number of the previous message, nor is it required that the hash of the previous message match the hash given for the previous message in a message.
 
 ## Benchmarks
 

--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 Validate Secure Scuttlebutt (SSB) hash chains (in parallel)
 
-:warning: **Warning: this fork deviates significantly from the Sunrise Choir repository.** The primary difference is in the strictness of validation, with this fork including additional validation checks. The aim here is to get as close as possible to the full set of validation criteria employed by the [JavaScript implementation of ssb-validate](https://github.com/ssb-js/ssb-validate).
+The aim here is to get as close as possible to the full set of validation criteria employed by the [JavaScript implementation of ssb-validate](https://github.com/ssb-js/ssb-validate).
 
 Support for out-of-order validation (regular and parallel) and multi-author out-of-order validation (regular and parallel) has been added.
 
 ## Usage
 
-Visit the [ssb-validate2-rsjs](https://github.com/ssb-ngi-pointer/ssb-validate2-rsjs) repo (the `src/lib.rs` file in particular) to see examples of this crate in action. The validation functionality is paired with [ssb-verify-signatures](https://github.com/sunrise-choir/ssb-verify-signatures) to perform complete validation of SSB messages. A technique for returning an invalid message when performing parallel validation is also included in the code.
+Visit the [ssb-validate2-rsjs-node](https://github.com/ssb-ngi-pointer/ssb-validate2-rsjs-node) repo (the `src/lib.rs` file in particular) to see examples of this crate in action. The validation functionality is paired with [ssb-verify-signatures](https://github.com/sunrise-choir/ssb-verify-signatures) to perform complete validation of SSB messages. A technique for returning an invalid message when performing parallel validation is also included in the code.
 
 Further examples can be seen in the tests of `src/lib.rs` in this repo.
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ To be valid, a message should satisfy the following criteria:
  - message value keys must be in the order: "previous", "author"|"sequence", "author"|"sequence", "timestamp", "hash", "content", "signature"
  - the message value must not include extra fields
  - if the message content is a string (encrypted private message) it must be encoded in canonical base64 and end with `.box`
+ - the length of the serialized message value must not exceed 8192 UTF-16 code units
 
 All of the above criteria are validated by this library (either directly or via dependencies).
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ To be valid, a message should satisfy the following criteria:
    - unless it is the first message in feed, in which case previous must be null
  - include a sequence number which is 1 larger than the sequence number of the previous message
    - unless it is the first message in a feed, in which case the sequence number must be 1 and the sequence number of the previous message must be null
+ - include a hash function field with value `sha256`
  - the author must not change compared to the previous message
  - if the message includes a key, it must be the hash of the value of the message
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ To be valid, a message should satisfy the following criteria:
  - include a hash function field with value `sha256`
  - the author must not change compared to the previous message
  - if the message includes a key, it must be the hash of the value of the message
+ - the message value must not include extra fields
+ - if the message content is a string (encrypted private message) it must be encoded in canonical base64 and end with `.box`
+
+All of the above criteria are validated by this library (either directly or via dependencies).
 
 You can check messages one by one or batch process a collection of them (uses [rayon](https://docs.rs/rayon/1.2.0/rayon/index.html) internally)
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,8 +16,9 @@
 //!
 //! Benchmarking on Android on a [One Plus 5T](https://en.wikipedia.org/wiki/OnePlus_5T) (8 core arm64) shows that batch processing is ~3.3 times faster.
 //!
+use lazy_static::lazy_static;
 use rayon::prelude::*;
-use regex::Regex;
+use regex::bytes::Regex;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use snafu::{ensure, OptionExt, ResultExt, Snafu};
@@ -38,6 +39,8 @@ pub enum Error {
         source: DecodeJsonError,
         message: Vec<u8>,
     },
+    #[snafu(display("Message must have keys in correct order",))]
+    InvalidMessageValueOrder { message: Vec<u8> },
     #[snafu(display(
         "Message was invalid. The authors did not match. \nAuthor of previous: {}\n Author: {} ",
         previous_author,
@@ -138,6 +141,22 @@ pub fn validate_ooo_message_hash_chain<T: AsRef<[u8]>, U: AsRef<[u8]>>(
     })?;
 
     let message_value = message.value;
+
+    // The message value fields are in the correct order.
+    ensure!(
+        is_correct_order(message_bytes),
+        InvalidMessageValueOrder {
+            message: message_bytes.to_owned()
+        }
+    );
+
+    // The hash signature must be `sha256`.
+    ensure!(
+        message_value.hash == "sha256",
+        InvalidHashFunction {
+            message: message_bytes.to_owned()
+        }
+    );
 
     if let Some(previous_value) = previous_value.as_ref() {
         // The authors are not allowed to change in a feed.
@@ -608,12 +627,27 @@ fn multihash_from_bytes(bytes: &[u8]) -> Multihash {
     Multihash::Message(value_hash.into())
 }
 
+fn is_correct_order(bytes: &[u8]) -> bool {
+    lazy_static! {
+        static ref RE: Regex = Regex::new(r#""previous"[\s\S]*("author"|"sequence")[\s\S]*("author"|"sequence")[\s\S]*"timestamp"[\s\S]*"hash"[\s\S]*"content"[\s\S]*"signature""#).unwrap();
+    }
+    RE.is_match(bytes)
+}
+
 fn message_value_common_checks(
     message_value: &SsbMessageValue,
     previous_value: Option<&SsbMessageValue>,
     message_bytes: &[u8],
     previous_key: Option<&Multihash>,
 ) -> Result<()> {
+    // The message value fields are in the correct order.
+    ensure!(
+        is_correct_order(message_bytes),
+        InvalidMessageValueOrder {
+            message: message_bytes.to_owned()
+        }
+    );
+
     // The hash signature must be `sha256`.
     ensure!(
         message_value.hash == "sha256",
@@ -907,6 +941,17 @@ mod tests {
         assert!(result.is_ok());
     }
     #[test]
+    fn it_detects_incorrect_message_value_order() {
+        let result = validate_message_hash_chain(
+            MESSAGE_2_INVALID_ORDER.as_bytes(),
+            Some(MESSAGE_1.as_bytes()),
+        );
+        match result {
+            Err(Error::InvalidMessageValueOrder { message: _ }) => {}
+            _ => panic!(),
+        }
+    }
+    #[test]
     fn it_validates_a_private_message() {
         let result = validate_message_hash_chain(
             MESSAGE_PRIVATE.as_bytes(),
@@ -921,7 +966,6 @@ mod tests {
             MESSAGE_PRIVATE_INVALID.as_bytes(),
             Some(MESSAGE_PRIVATE_PREV.as_bytes()),
         );
-
         match result {
             Err(Error::InvalidBase64 { message: _ }) => {}
             _ => panic!(),
@@ -1001,6 +1045,30 @@ mod tests {
     "sequence": 2,
     "timestamp": 1470187292812,
     "hash": "sha256",
+    "content": {
+      "type": "about",
+      "about": "@U5GvOKP/YUza9k53DSXxT0mk3PIrnyAmessvNfZl5E0=.ed25519",
+      "image": {
+        "link": "&MxwsfZoq7X6oqnEX/TWIlAqd6S+jsUA6T1hqZYdl7RM=.sha256",
+        "size": 642763,
+        "type": "image/png",
+        "width": 512,
+        "height": 512
+      }
+    },
+    "signature": "j3C7Us3JDnSUseF4ycRB0dTMs0xC6NAriAFtJWvx2uyz0K4zSj6XL8YA4BVqv+AHgo08+HxXGrpJlZ3ADwNnDw==.sig.ed25519"
+  },
+  "timestamp": 1571140551485
+}"##;
+
+    const MESSAGE_2_INVALID_ORDER: &str = r##"{
+  "key": "%kLWDux4wCG+OdQWAHnpBGzGlCehqMLfgLbzlKCvgesU=.sha256",
+  "value": {
+    "previous": "%/v5mCnV/kmnVtnF3zXtD4tbzoEQo4kRq/0d/bgxP1WI=.sha256",
+    "author": "@U5GvOKP/YUza9k53DSXxT0mk3PIrnyAmessvNfZl5E0=.ed25519",
+    "sequence": 2,
+    "hash": "sha256",
+    "timestamp": 1470187292812,
     "content": {
       "type": "about",
       "about": "@U5GvOKP/YUza9k53DSXxT0mk3PIrnyAmessvNfZl5E0=.ed25519",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@
 //! Benchmarking on Android on a [One Plus 5T](https://en.wikipedia.org/wiki/OnePlus_5T) (8 core arm64) shows that batch processing is ~3.3 times faster.
 //!
 use rayon::prelude::*;
+use regex::Regex;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use snafu::{ensure, OptionExt, ResultExt, Snafu};
@@ -52,6 +53,8 @@ pub enum Error {
     FirstMessageDidNotHavePreviousOfNull { message: Vec<u8> },
     #[snafu(display("The message hash must be 'sha256'",))]
     InvalidHashFunction { message: Vec<u8> },
+    #[snafu(display("The message content string must be canonical base64",))]
+    InvalidBase64 { message: Vec<u8> },
     #[snafu(display("The sequence must increase by one",))]
     InvalidSequenceNumber {
         message: Vec<u8>,
@@ -619,6 +622,19 @@ fn message_value_common_checks(
         }
     );
 
+    // The message `content` string must be canonical base64.
+    if let Value::String(private_msg) = &message_value.content.0 {
+        // Regex pattern to match on canonical base64 for private messages.
+        // Implemented according to the `is-canonical-base64` JS module by dominictarr.
+        let re = Regex::new(r"^(?:[a-zA-Z0-9/+]{4})*(?:[a-zA-Z0-9/+](?:(?:[AQgw]==)|(?:[a-zA-Z0-9/+][AEIMQUYcgkosw048]=)))?.box.*$").unwrap();
+        ensure!(
+            re.is_match(private_msg),
+            InvalidBase64 {
+                message: message_bytes,
+            }
+        );
+    }
+
     if let Some(previous_value) = previous_value {
         // The authors are not allowed to change in a feed.
         ensure!(
@@ -889,6 +905,27 @@ mod tests {
         );
 
         assert!(result.is_ok());
+    }
+    #[test]
+    fn it_validates_a_private_message() {
+        let result = validate_message_hash_chain(
+            MESSAGE_PRIVATE.as_bytes(),
+            Some(MESSAGE_PRIVATE_PREV.as_bytes()),
+        );
+
+        assert!(result.is_ok());
+    }
+    #[test]
+    fn it_detects_invalid_base64_for_private_message() {
+        let result = validate_message_hash_chain(
+            MESSAGE_PRIVATE_INVALID.as_bytes(),
+            Some(MESSAGE_PRIVATE_PREV.as_bytes()),
+        );
+
+        match result {
+            Err(Error::InvalidBase64 { message: _ }) => {}
+            _ => panic!(),
+        }
     }
 
     const MESSAGE_1: &str = r##"{
@@ -1222,5 +1259,54 @@ mod tests {
     "extra": "INVALID"
     },
   "timestamp": 1571140555382.002
+}"##;
+
+    const MESSAGE_PRIVATE: &str = r##"{
+  "key": "%uN9G3nZ+IYrCiC8Qmqb8J8hnefc486pZGeWyqBomAi8=.sha256",
+  "value": {
+    "previous": "%Z694dkKDUmNtoSwwjLG9cl7j0Dd26EDp0DRDmyPl1Lc=.sha256",
+    "sequence": 24148,
+    "author": "@iL6NzQoOLFP18pCpprkbY80DMtiG4JFFtVSVUaoGsOQ=.ed25519",
+    "timestamp": 1620171292121,
+    "hash": "sha256",
+    "content": "siZEm1zFx1icq0SrEynGDpNRmJCXMxTB3iEteXFn+IhJH8WhMbT8tp9qOIaFkIYcdOyerSon6RK0l4RE1ZdDh/3lcGZSdP0Ljq59qsdqlf2ngwbIbV9AWdPRrPsoVZBV6RhI+YcVTloWWP5aauu1hZKjcm62ezLBTQ3EmFPYtDuwsOFkx9/7FP97ljhj67CwvlGzuiWp6FNICHbt5kOCxs9H0k6Tr8JJVdaJtJ2pqkX4p0ECMuEuYxCYbh3FpncCqlNZJXb0dj3iSsfsMNWTJLDqfkqJKH1jBVfxDL6+xAXBDS+E4F2hD4y9gRDZEej99uVBQWlbxr5eCRV+VbfBGYxwoAYtqux6rg3jBabImKKinBwHShEP5F/+wlb9IxQn4swyOgyv+UKx/jbx+91Ayso5bnNPZMpwRRX5p5DbpK1BnryeVJhktMgFqgni1g0lHyU8sQ2QzwZgXGw7dfYoamkqK4D24NOLnUoHuVuhd7Q5SxZWSAO6wpDa4nrODePoJdl328pbMwCoQlUNeHINmKxh/o/oCNbgXitn4oN3kSVEg/umdgwwI94gmZUjiYwP1v7HA7dI.box",
+    "signature": "n4Wepa4fxq+xLlmfCxwiC489rMZlnnrBFOkWMuGAv80O7GK0XZUn1zfuCP9fQBab1+P0m1g+OLiyWwqHnwdTBw==.sig.ed25519"
+    },
+  "timestamp": 1620198134771
+}"##;
+
+    const MESSAGE_PRIVATE_PREV: &str = r##"{
+  "key": "%Z694dkKDUmNtoSwwjLG9cl7j0Dd26EDp0DRDmyPl1Lc=.sha256",
+  "value": {
+    "previous": "%cN1F3DkKC3bfxZlwWY98xqzsoQGEC9sRNe9HYm6khhk=.sha256",
+    "sequence": 24147,
+    "author": "@iL6NzQoOLFP18pCpprkbY80DMtiG4JFFtVSVUaoGsOQ=.ed25519",
+    "timestamp": 1620136240655,
+    "hash": "sha256",
+    "content": {
+      "type": "vote",
+      "vote": {
+        "link": "%SXw+GJZZBvS7neNDfuyu2UXmGD3Gl8jMxX2PPc7sjCs=.sha256",
+        "value": 1,
+        "expression": "Like"
+      }
+    },
+    "signature": "iA958Ct3+9Z3tZZcbXvF4BAFVPJZ8MhfqnWOgzwhLdviL1KE3xTKn4joJl1a+mnqSLHbH/QT3NHQu378GdsHBg==.sig.ed25519"
+    },
+  "timestamp": 1620137278131.001
+}"##;
+
+    const MESSAGE_PRIVATE_INVALID: &str = r##"{
+  "key": "%uN9G3nZ+IYrCiC8Qmqb8J8hnefc486pZGeWyqBomAi8=.sha256",
+  "value": {
+    "previous": "%Z694dkKDUmNtoSwwjLG9cl7j0Dd26EDp0DRDmyPl1Lc=.sha256",
+    "sequence": 24148,
+    "author": "@iL6NzQoOLFP18pCpprkbY80DMtiG4JFFtVSVUaoGsOQ=.ed25519",
+    "timestamp": 1620171292121,
+    "hash": "sha256",
+    "content": "==siZEm1zFx1icq0SrEynGDpNRmJCXMxTB3iEteXFn+IhJH8WhMbT8tp9qOIaFkIYcdOyerSon6RK0l4RE1ZdDh/3lcGZSdP0Ljq59qsdqlf2ngwbIbV9AWdPRrPsoVZBV6RhI+YcVTloWWP5aauu1hZKjcm62ezLBTQ3EmFPYtDuwsOFkx9/7FP97ljhj67CwvlGzuiWp6FNICHbt5kOCxs9H0k6Tr8JJVdaJtJ2pqkX4p0ECMuEuYxCYbh3FpncCqlNZJXb0dj3iSsfsMNWTJLDqfkqJKH1jBVfxDL6+xAXBDS+E4F2hD4y9gRDZEej99uVBQWlbxr5eCRV+VbfBGYxwoAYtqux6rg3jBabImKKinBwHShEP5F/+wlb9IxQn4swyOgyv+UKx/jbx+91Ayso5bnNPZMpwRRX5p5DbpK1BnryeVJhktMgFqgni1g0lHyU8sQ2QzwZgXGw7dfYoamkqK4D24NOLnUoHuVuhd7Q5SxZWSAO6wpDa4nrODePoJdl328pbMwCoQlUNeHINmKxh/o/oCNbgXitn4oN3kSVEg/umdgwwI94gmZUjiYwP1v7HA7dI.box",
+    "signature": "n4Wepa4fxq+xLlmfCxwiC489rMZlnnrBFOkWMuGAv80O7GK0XZUn1zfuCP9fQBab1+P0m1g+OLiyWwqHnwdTBw==.sig.ed25519"
+    },
+  "timestamp": 1620198134771
 }"##;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use snafu::{ensure, OptionExt, ResultExt, Snafu};
 use ssb_legacy_msg_data::json::{from_slice, to_vec, DecodeJsonError, EncodeJsonError};
-use ssb_legacy_msg_data::value::Value;
+use ssb_legacy_msg_data::value::{ContentValue, Value};
 use ssb_legacy_msg_data::LegacyF64;
 use ssb_multiformats::multihash::Multihash;
 
@@ -87,7 +87,7 @@ struct SsbMessageValue {
     sequence: u64,
     timestamp: LegacyF64,
     hash: String,
-    content: Value,
+    content: ContentValue,
     signature: String,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,8 @@
 //!
 use lazy_static::lazy_static;
 use rayon::prelude::*;
-use regex::bytes::Regex;
+use regex::bytes::Regex as RegexBytes;
+use regex::Regex;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use snafu::{ensure, OptionExt, ResultExt, Snafu};
@@ -629,7 +630,7 @@ fn multihash_from_bytes(bytes: &[u8]) -> Multihash {
 
 fn is_correct_order(bytes: &[u8]) -> bool {
     lazy_static! {
-        static ref RE: Regex = Regex::new(r#""previous"[\s\S]*("author"|"sequence")[\s\S]*("author"|"sequence")[\s\S]*"timestamp"[\s\S]*"hash"[\s\S]*"content"[\s\S]*"signature""#).unwrap();
+        static ref RE: RegexBytes = RegexBytes::new(r#""previous"[\s\S]*("author"|"sequence")[\s\S]*("author"|"sequence")[\s\S]*"timestamp"[\s\S]*"hash"[\s\S]*"content"[\s\S]*"signature""#).unwrap();
     }
     RE.is_match(bytes)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,6 +87,7 @@ struct SsbMessageValue {
     sequence: u64,
     timestamp: LegacyF64,
     hash: String,
+    content: Value,
     signature: String,
 }
 
@@ -1175,7 +1176,7 @@ mod tests {
   "timestamp": 1571140555382.002
 }"##;
 
-const MESSAGE_WITHOUT_HASH_FUNCTION: &str = r##"{
+    const MESSAGE_WITHOUT_HASH_FUNCTION: &str = r##"{
   "key": "%8Y0PR6EAoyObJhJZf2YQNn5B3RaCDzsrVrj2XxgRPhE=.sha256",
   "value": {
     "previous": null,
@@ -1206,7 +1207,7 @@ const MESSAGE_WITHOUT_HASH_FUNCTION: &str = r##"{
   "timestamp": 1571140555382.002
 }"##;
 
-const MESSAGE_WITH_EXTRA_FIELD: &str = r##"{
+    const MESSAGE_WITH_EXTRA_FIELD: &str = r##"{
   "key": "%aR6KXa2nhQicxWGOv3ECWjUeysve/0p1HTAGmnt7u2w=.sha256",
   "value": {
     "previous": null,


### PR DESCRIPTION
This PR bundles many smaller PR's which were made on my [fork of ssb-validate](https://github.com/mycognosist/ssb-validate).

The goal of the code in this submission is two-fold:

1) Bring this library as close as possible to consistency with the JavaScript implementation of [ssb-validate](https://github.com/ssb-js/ssb-validate)
2) Support out-of-order message validation for single author and multi-author use cases.

A summary of the changes introduced here:

 - Support out-of-order validation
 - Add checks for hash signature (`sha256`)
 - Deny unknown (extra) fields in message value
 - Add stricter content deserialization (`Value` -> `ContentValue`)
 - Add canonical base64 check for private messages
 - Implement message key ordering check with Regex
 - Support multi-author out-of-order validation
 - Add message value length check
 - Add unit tests for all new functionality
 - Extend documentation (validation criteria, usage, useful documentation links)

Some of the increased validation strictness has been made possible by modifications to the [legacy-msg-data](https://github.com/sunrise-choir/legacy-msg-data) (primarily in terms of deserialization methods). Those changes have been merged.

I have done my best to conform to the original structure and approach of the library. Unit tests have been added to ensure coverage of the introduced changes. These changes have also been comprehensively tested with the help of Christian Bundy's [ssb-validation-dataset](https://github.com/fraction/ssb-validation-dataset). Further details of this journey can be found in my Scuttlebutt dev-diary (`%7f+MTg7rqgQtyqVRtndSWCNXC3jMT3xzWKzrtNUQE6Y=.sha256`).

I have bumped the version number of the library and added myself as a co-author (I hope this was not too presumptuous of me! 🙏🏻 ).