### PR TITLE
Make message-related structs public

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssb-validate"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["Piet Geursen <pietgeursen@gmail.com>", "Andrew Reid <glyph@mycelial.technology>"]
 edition = "2018"
 description = "Verify Secure Scuttlebutt (SSB) hash chains (in parallel)"
@@ -14,7 +14,7 @@ regex = "1.5"
 serde = { version = "1.0", features = ["derive"] }
 sha2 = "0.8.0"
 snafu = "0.6.0"
-ssb-legacy-msg-data = { git = "https://github.com/mycognosist/legacy-msg-data" }
+ssb-legacy-msg-data = { git = "https://github.com/sunrise-choir/legacy-msg-data" }
 ssb-multiformats = "0.4.0" 
 rayon = "1.2.0"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,7 +90,7 @@ type Result<T, E = Error> = std::result::Result<T, E>;
 
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(deny_unknown_fields)]
-struct SsbMessageValue {
+pub struct SsbMessageValue {
     previous: Option<Multihash>,
     author: String,
     sequence: u64,
@@ -101,9 +101,9 @@ struct SsbMessageValue {
 }
 
 #[derive(Serialize, Deserialize, Debug)]
-struct SsbMessage {
-    key: Multihash,
-    value: SsbMessageValue,
+pub struct SsbMessage {
+    pub key: Multihash,
+    pub value: SsbMessageValue,
 }
 
 /// Check that an out-of-order message is valid without checking the author.
@@ -691,7 +691,7 @@ pub fn validate_message_value_hash_chain<T: AsRef<[u8]>, U: AsRef<[u8]>>(
     Ok(())
 }
 
-fn multihash_from_bytes(bytes: &[u8]) -> Multihash {
+pub fn multihash_from_bytes(bytes: &[u8]) -> Multihash {
     let value_bytes_latin = node_buffer_binary_serializer(std::str::from_utf8(bytes).unwrap());
     let value_hash = Sha256::digest(value_bytes_latin.as_slice());
     Multihash::Message(value_hash.into())


### PR DESCRIPTION
 - Export the `SsbMessage` and `SsbMessageValue` structs for convenient use by libraries which depend on `ssb-validate`
 - Exports the `multihash_from_bytes` function
 - Update the `ssb-legacy-msg-data` dependency to pull from the Sunrise Choir repo
 - Bump version to `1.2.1`