### PR TITLE
Bump version to allow new license release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssb-validate"
-version = "1.4.0"
+version = "1.4.1"
 authors = ["Piet Geursen <pietgeursen@gmail.com>", "Andrew Reid <glyph@mycelial.technology>"]
 edition = "2018"
 description = "Verify Secure Scuttlebutt (SSB) hash chains (in parallel)"


### PR DESCRIPTION
We can't publish the latest version (with LGPL-3.0 license) to crates.io unless we bump the version number.

`1.4.0` -> `1.4.1`