### PR TITLE
Bump versions for crate and ssb dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssb-validate"
-version = "1.4.1"
+version = "1.4.2"
 authors = ["Piet Geursen <pietgeursen@gmail.com>", "Andrew Reid <glyph@mycelial.technology>"]
 edition = "2018"
 description = "Verify Secure Scuttlebutt (SSB) hash chains (in parallel)"
@@ -14,8 +14,8 @@ regex = "1.5"
 serde = { version = "1.0", features = ["derive"] }
 sha2 = "0.8.0"
 snafu = "0.6.0"
-ssb-legacy-msg-data = "0.1.3"
-ssb-multiformats = "0.4.1"
+ssb-legacy-msg-data = "0.1.4"
+ssb-multiformats = "0.4.2"
 rayon = "1.2.0"
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ssb-validate
 
-[![Build Status](https://travis-ci.org/sunrise-choir/ssb-validate.svg?branch=master)](https://travis-ci.org/github/sunrise-choir/ssb-validate) ![Version badge](https://img.shields.io/badge/version-1.4.1-blue.svg) [![Documentation badge](https://img.shields.io/badge/rust-docs-blue)](https://sunrise-choir.github.io/ssb-validate/ssb_validate/index.html)
+[![Build Status](https://travis-ci.org/sunrise-choir/ssb-validate.svg?branch=master)](https://travis-ci.org/github/sunrise-choir/ssb-validate) ![Version badge](https://img.shields.io/badge/version-1.4.2-blue.svg) [![Documentation badge](https://img.shields.io/badge/rust-docs-blue)](https://sunrise-choir.github.io/ssb-validate/ssb_validate/index.html)
 
 Validate Secure Scuttlebutt (SSB) message and message values, either individually or as hash chains (with support for parallel batch validation).
 


### PR DESCRIPTION
`ssb-multiformats` dependency `0.4.1` -> `0.4.2`
`ssb-legacy-msg-data` dependency `0.1.3` -> `0.1.4`

Repo version `1.4.1` -> `1.4.2`